### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-transformers>=4.35.1
-datasets[audio]>=2.14.7
-accelerate>=0.24.1
+transformers==4.35.1
+datasets[audio]==2.14.7
+accelerate==0.24.1
 matplotlib
 wandb
 tensorboard


### PR DESCRIPTION
Higher versions of `datasets`, `transformers`, and `accelerate` threw an error for me (see https://github.com/ylacombe/finetune-hf-vits/issues/22) so I suggest that `requirements.txt` specify the exact package versions. 