### PR TITLE
deprecated method tostring_rgb() changed with buffer_rgba

### DIFF
--- a/utils/plot.py
+++ b/utils/plot.py
@@ -1,7 +1,6 @@
 import logging
 import matplotlib
 
-
 matplotlib.use("Agg")
 
 MATPLOTLIB_FLAG = False
@@ -27,8 +26,8 @@ def plot_spectrogram_to_numpy(spectrogram):
     plt.tight_layout()
 
     fig.canvas.draw()
-    data = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    # CHANGED: Updated deprecated tostring_rgb() to use renderer.buffer_rgba()[:,:,:3]
+    data = np.asarray(fig.canvas.renderer.buffer_rgba())[:,:,:3]
     plt.close()
     return data
 
@@ -56,7 +55,7 @@ def plot_alignment_to_numpy(alignment, info=None):
     plt.tight_layout()
 
     fig.canvas.draw()
-    data = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    # CHANGED: Updated deprecated tostring_rgb() to use renderer.buffer_rgba()[:,:,:3]
+    data = np.asarray(fig.canvas.renderer.buffer_rgba())[:,:,:3]
     plt.close()
     return data


### PR DESCRIPTION
Fixing the following error that occurs during validation
File "/content/finetune-hf-vits/utils/plot.py", line 59, in plot_alignment_to_numpy
    data = np.frombuffer(fig.canvas.tostring_rgb(), dtype=np.uint8)
AttributeError: 'FigureCanvasAgg' object has no attribute 'tostring_rgb

MatplotlibDeprecationWarning: [#227](https://github.com/CASIA-IVA-Lab/FastSAM/issues/227)